### PR TITLE
removed-dashboard-link-in-navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,6 @@
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
-      <%= link_to "Dashboard", dashboard_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to "Create spaceship", new_spaceship_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to "My bookings", dashboard_path, class: "navbar-wagon-item navbar-wagon-link" %>
 


### PR DESCRIPTION
removed the dashboard link in the navbar because it doesn't make sense to have dashboard link on the navbar. Since we have my bookings and my profile link in the drop down menu - Pending Review